### PR TITLE
정솔리: 게임

### DIFF
--- a/sollyj/june_4/게임.java
+++ b/sollyj/june_4/게임.java
@@ -1,0 +1,46 @@
+package sollyj.june_4;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 게임 {
+	public static void main(String[] args) {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+
+			long X = Long.parseLong(st.nextToken());
+			long Y = Long.parseLong(st.nextToken());
+
+			long now = Y * 100 / X;    // 현재 승률
+			int count;
+			boolean flag = true;    // Z가 변하는지 확인하기 위한 flag
+
+			if (now >= 99) {    // 99%와 100%는 확률이 변하지 않는다.
+				flag = false;
+			}
+
+			// 이분탐색
+			long start = 0;
+			long end = X;    // 최대는 지금까지의 게임 횟수
+			while (start <= end) {
+				long mid = (start + end) / 2;
+
+				long tempRate = (Y + mid) * 100 / (X + mid);
+
+				if (tempRate > now) {    // 승률이 올랐다면 end를 줄여준다
+					end = mid - 1;
+				} else {    // 작거나 같다면 start를 늘려준다
+					start = mid + 1;
+				}
+			}
+
+			// while문을 끝내고 최솟값을 구하는 것이므로 start를 출력
+			count = flag ? (int)start : -1;
+
+			System.out.println(count);
+		} catch (Exception e) {
+			System.out.println(e.getLocalizedMessage());
+		}
+	}
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1072 게임](https://www.acmicpc.net/problem/1072)

---

### 💡 문제에서 사용된 알고리즘

- 이분탐색

---

### 📜 코드 설명

- 이 문제는 X, Y를 +1씩하면서 승률을 비교하면 시간초과가 난다.
- 그러므로 `이분탐색` 으로 풀어야한다.

- start = 0  **end = X**
_**end가 X**인 이유_
최대횟수는 지금까지의 게임 횟수다.
다시 말하면, 지금까지 한 게임 횟수 만큼 더 했는데도 승률이 안 오른다는 것은 승률이 변하지 않는다는 얘기
- 승률이 올랐다면 end를 줄여주고, 승률이 작거나 같다면 start를 늘려주며 이분탐색을 하고
- while문이 끝났으면 최솟값을 구하는 것이므로 start를 출력한다.
(이 때 flag를 확인한다.)

---

close #91 