### PR TITLE
정솔리: 완전이진트리

### DIFF
--- a/sollyj/july_4/완전이진트리.java
+++ b/sollyj/july_4/완전이진트리.java
@@ -1,0 +1,55 @@
+package sollyj.july_4;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class 완전이진트리 {
+	static int K;    // 레벨
+	static List<Integer> nodeList;    // 방문한 노드 번호 순서대로 넣을 리스트
+	static List<Integer>[] tree;    // tree[i]에는 i레벨에 해당하는 노드들 넣어줌
+
+	public static void main(String[] args) {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+			K = Integer.parseInt(br.readLine());
+			nodeList = new ArrayList<>();
+			tree = new ArrayList[K + 1];
+
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int i = 0; i < Math.pow(2, K) - 1; i++) {
+				nodeList.add(Integer.parseInt(st.nextToken()));
+			}
+
+			for (int i = 1; i <= K; i++) {
+				tree[i] = new ArrayList<>();
+			}
+
+			recurrence(0, nodeList.size() - 1, 1);
+
+			for (int i = 1; i <= K; i++) {
+				for (int node : tree[i]) {
+					System.out.print(node + " ");
+				}
+				System.out.println();
+			}
+		} catch (Exception e) {
+			System.out.println(e.getLocalizedMessage());
+		}
+	}
+
+	private static void recurrence(int start, int end, int level) {
+		if (level > K) {
+			return;
+		}
+
+		// 현재 level의 루트 노드 인덱스
+		int mid = (start + end) / 2;
+
+		tree[level].add(nodeList.get(mid));
+
+		recurrence(start, mid - 1, level + 1);    // 왼쪽 재귀
+		recurrence(mid + 1, end, level + 1);    // 오른쪽 재귀
+	}
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 9934 완전이진트리](https://www.acmicpc.net/problem/9934)

---

### 💡 문제에서 사용된 알고리즘

- 재귀
- DFS

---

### 📜 코드 설명

- `K`
레벨 (깊이)
- `nodeList`
방문한 노드 번호 순서대로 넣을 리스트
입력 값들
- `tree`
리스트배열
tree[i]에는 i레벨에 해당하는 노드들 넣어줌
출력할 값들
- `recurrence(탐색할 시작 인덱스, 탐색할 마지막 인덱스, 레벨)`
왼쪽 -> 루트 -> 오른쪽 이런식으로 중위순회를 하므로, 트리를 채울땐 로직을 반대로 가면 된다.
1. 루트 노드를 먼저 찾는다. (`mid`)
2. 왼쪽 부분에서 루트 노드를 찾는다. (**재귀**)
3. 오른쪽 부분에서 루트 노드를 찾는다. (**재귀**)
4. ...주어진 깊이(`K`) 까지 반복 


---

close #180 