### PR TITLE
정솔리: 예산

### DIFF
--- a/sollyj/aug_3/예산.java
+++ b/sollyj/aug_3/예산.java
@@ -1,0 +1,51 @@
+package sollyj.aug_3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class 예산 {
+	public static void main(String[] args) {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+			int N = Integer.parseInt(br.readLine());
+			int[] request = new int[N];
+
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int i = 0; i < N; i++) {
+				request[i] = Integer.parseInt(st.nextToken());
+			}
+			Arrays.sort(request);    // 오름차순 정렬
+
+			int budget = Integer.parseInt(br.readLine());
+
+			// 이분탐색
+			int start = 1;
+			int end = request[N - 1];
+			int limit = 0;    // 상한액
+			while (start <= end) {
+				int temp_limit = (start + end) / 2;
+				int sum = 0;
+
+				for (int i = 0; i < N; i++) {
+					if (request[i] <= temp_limit) {    // 예산요청이 상한액보다 작거나 같으면 그대로 더한다
+						sum += request[i];
+					} else {    // 예산요청이 상한액보다 크면 상한액을 더한다
+						sum += temp_limit;
+					}
+				}
+
+				if (sum > budget)
+					end--;
+				else {    // 합이 총 예산보다 작거나 같으면 일단 limit에 저장해두고 상한액을 늘려서 다시 탐색 해본다.
+					limit = temp_limit;
+					start++;
+				}
+			}
+
+			System.out.println(limit);
+		} catch (Exception e) {
+			System.out.println(e.getLocalizedMessage());
+		}
+	}
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 2512 예산](https://www.acmicpc.net/problem/2512)

---

### 💡 문제에서 사용된 알고리즘

- 이분탐색

---

### 📜 코드 설명

- 예산요청을 `request`배열에 넣어주고 오름차순 정렬 해준다.
- `start` = 1, `end` = 요청예산 중 가장 큰 값으로 두고 **이분탐색**을 한다.
- `temp_limit`에는 중간값을 넣어서 임시 상한액으로 설정해둔다.
- 임시 상한액으로 다 더한 예산요청들의 합 `sum`과 나라의 총 예산 `budget`을 비교하여 `sum`이 더 크면 임시 상한액을 줄여야한다.
- `sum` <= `budget`이면 일단 `limit`에 임시 상한액을 저장해두고 임시 상한액을 줄여서 다시 탐색해본다.
- 최종적으로 `limit`을 출력 

---

close #232 
